### PR TITLE
Dynamic header height on page view

### DIFF
--- a/resources/translations/da_DK.ts
+++ b/resources/translations/da_DK.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation type="unfinished">%1 is %2</translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation type="unfinished">Press and hold the Home button or use the Web Configurator to configure the page</translation>

--- a/resources/translations/de_CH.ts
+++ b/resources/translations/de_CH.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation>%1 ist %2</translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation>Heb d Home-Taschte drückt oder bruch dr Web-Konfigurator für d Siite ds konfiguriere</translation>

--- a/resources/translations/de_DE.ts
+++ b/resources/translations/de_DE.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation>%1 ist %2</translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation>Um die Seite zu anzupassen, Home-Taste gedrückt halten oder Web-Konfigurator verwenden</translation>

--- a/resources/translations/en_US.ts
+++ b/resources/translations/en_US.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation type="unfinished"></translation>

--- a/resources/translations/fr_FR.ts
+++ b/resources/translations/fr_FR.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation>%1 est %2</translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation>Appuyez et maintenez le bouton Accueil ou utilisez le configurateur web pour configurer la page</translation>

--- a/resources/translations/hu_HU.ts
+++ b/resources/translations/hu_HU.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation type="unfinished">%1 is %2</translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation type="unfinished">Press and hold the Home button or use the Web Configurator to configure the page</translation>

--- a/resources/translations/it_IT.ts
+++ b/resources/translations/it_IT.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation type="unfinished">%1 is %2</translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation>Tieni premuto il pulsante Home o usa il configuratore Web per configurare la pagina</translation>

--- a/resources/translations/nl_NL.ts
+++ b/resources/translations/nl_NL.ts
@@ -1446,13 +1446,13 @@ Climate fan</extracomment>
 <context>
     <name>Page</name>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="182"/>
+        <location filename="../../src/qml/components/Page.qml" line="194"/>
         <source>%1 is %2</source>
         <extracomment>Used to show the entity state: %1 is the entity name, %2 is the state</extracomment>
         <translation>%1 is %2</translation>
     </message>
     <message>
-        <location filename="../../src/qml/components/Page.qml" line="203"/>
+        <location filename="../../src/qml/components/Page.qml" line="215"/>
         <source>Press and hold the Home button or use the Web Configurator to configure the page</source>
         <extracomment>Web configurator is the name of the application, does not need translation</extracomment>
         <translation>Houd de Home-knop ingedrukt of gebruik de webconfigurator om de pagina te configureren</translation>

--- a/src/qml/components/Page.qml
+++ b/src/qml/components/Page.qml
@@ -30,6 +30,7 @@ ListView {
     property string _id: pageId
     property QtObject items: pageItems
     property bool isCurrentItem: ListView.isCurrentItem
+    property int headerHeight: 260
 
     Behavior on height {
         NumberAnimation { easing.type: Easing.OutExpo; duration: 200 }
@@ -65,6 +66,16 @@ ListView {
             }
         }
     }
+    onContentYChanged: {
+            // Adjust the height of the header image based on overscroll
+            if (contentY < -260){
+                headerHeight= Math.max(-contentY, 260); // Adjust these values as needed
+                if (!dragging){
+                    contentY = -260;
+                }
+            }
+
+        }
 
     DelegateModel {
         id: visualModel
@@ -81,7 +92,7 @@ ListView {
 
             Image {
                 id: headerImage
-                width: parent.width; height: 260
+                width: parent.width; height: headerHeight
                 source: resource.getBackgroundImage(pageImage)
                 sourceSize.width: parent.width
                 sourceSize.height: 260
@@ -248,7 +259,6 @@ ListView {
 
             onReleased: {
                 page.interactive = true;
-
                 if (held) {
                     Haptic.play(Haptic.Click);
                     held = false;
@@ -361,3 +371,4 @@ ListView {
         }
     }
 }
+

--- a/src/qml/components/Page.qml
+++ b/src/qml/components/Page.qml
@@ -25,12 +25,16 @@ ListView {
     model: visualModel
     header: header
     currentIndex: 0
+    
+    // Disable scrolling when no items on page, otherwise header is movable
+    interactive: visualModel.count
 
     property string title: pageName
     property string _id: pageId
     property QtObject items: pageItems
     property bool isCurrentItem: ListView.isCurrentItem
     property int headerHeight: 260
+
 
     Behavior on height {
         NumberAnimation { easing.type: Easing.OutExpo; duration: 200 }
@@ -69,7 +73,8 @@ ListView {
     onContentYChanged: {
             // Adjust the height of the header image based on overscroll
             if (contentY < -260){
-                headerHeight= Math.max(-contentY, 260); // Adjust these values as needed
+                headerHeight= Math.max(-contentY, 260);
+                // Return the header to its normal size when we release 
                 if (!dragging){
                     contentY = -260;
                 }


### PR DESCRIPTION
First of all I'd like to start by saying that I love the remote.

One of the small things that was bothering me however with the UI was that the header image did not fill to the top of the view when over scrolling.  See also screenshot attached for visual clarification.
This pull request adds this change.

EDIT: Also updated the translation files as where necessary and removed a small bug where the header was movable when no items in list view. Thus allowing it to  be moved over the "Press and hold home button..." message

![screenshot](https://github.com/unfoldedcircle/remote-ui/assets/1469494/99e0fe43-1c51-405f-9ad7-45fc9ffd97ac)
